### PR TITLE
add dockerfile for ubuntu22.04 and python3.10, and test pass

### DIFF
--- a/docker/docker_file/ubuntu_22_04_cp310/Dockerfile_ubuntu_22_04_for_cp310
+++ b/docker/docker_file/ubuntu_22_04_cp310/Dockerfile_ubuntu_22_04_for_cp310
@@ -1,0 +1,26 @@
+FROM ubuntu:22.04
+
+COPY sources_bionic.list /etc/apt/sources.list
+
+ENV DEBIAN_FRONTEND=noninteractive
+
+RUN apt-get update \
+	&& apt-get install -y python3 python3-dev python3-pip gcc vim libprotobuf-dev zlib1g zlib1g-dev libsm6 \
+	&& apt-get install -y libgl1 libglib2.0-0 android-tools-adb
+
+RUN cd /usr/bin \
+	&& ln -sfn idle3 idle \
+	&& ln -sfn pydoc3 pydoc \
+	&& ln -sfn python3 python \
+	&& ln -sfn python3-config python-config \
+	&& ln -sfn pip3 pip \
+	&& ls -al
+
+RUN python -m pip install --upgrade pip -i https://mirror.baidu.com/pypi/simple --trusted-host=mirror.baidu.com
+RUN pip3 config set global.index-url https://mirror.baidu.com/pypi/simple
+RUN pip3 config set install.trusted-host mirror.baidu.com
+
+RUN python3 --version
+RUN pip3 --version
+COPY rknn_toolkit2-1.5.0+1fa95b5c-cp310-cp310-linux_x86_64.whl rknn_toolkit2-1.5.0+1fa95b5c-cp310-cp310-linux_x86_64.whl
+RUN pip3 install rknn_toolkit2-1.5.0+1fa95b5c-cp310-cp310-linux_x86_64.whl

--- a/docker/docker_file/ubuntu_22_04_cp310/sources_bionic.list
+++ b/docker/docker_file/ubuntu_22_04_cp310/sources_bionic.list
@@ -1,0 +1,13 @@
+# 默认注释了源码镜像以提高 apt update 速度，如有需要可自行取消注释
+deb http://mirrors.tuna.tsinghua.edu.cn/ubuntu/ jammy main restricted universe multiverse
+# deb-src http://mirrors.tuna.tsinghua.edu.cn/ubuntu/ jammy main restricted universe multiverse
+deb http://mirrors.tuna.tsinghua.edu.cn/ubuntu/ jammy-updates main restricted universe multiverse
+# deb-src http://mirrors.tuna.tsinghua.edu.cn/ubuntu/ jammy-updates main restricted universe multiverse
+deb http://mirrors.tuna.tsinghua.edu.cn/ubuntu/ jammy-backports main restricted universe multiverse
+# deb-src http://mirrors.tuna.tsinghua.edu.cn/ubuntu/ jammy-backports main restricted universe multiverse
+deb http://mirrors.tuna.tsinghua.edu.cn/ubuntu/ jammy-security main restricted universe multiverse
+# deb-src http://mirrors.tuna.tsinghua.edu.cn/ubuntu/ jammy-security main restricted universe multiverse
+
+# 预发布软件源，不建议启用
+# deb http://mirrors.tuna.tsinghua.edu.cn/ubuntu/ jammy-proposed main restricted universe multiverse
+# deb-src http://mirrors.tuna.tsinghua.edu.cn/ubuntu/ jammy-proposed main restricted universe multiverse


### PR DESCRIPTION
Add the folder contains the dockerfile for ubuntu22.04 and python3.10.
And test the yolov5 onnx2rknn with this image: ubuntu22.04_py310, it passed!
Maybe, it will be a help for people who want to use a newest os and python version.
Best Regards!